### PR TITLE
Fix for blade directives.

### DIFF
--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -32,25 +32,25 @@ class MarkdownServiceProvider extends ServiceProvider
     {
         // Markdown Style Blade Directive
         Blade::directive('markdownstyle', function ($file) {
-            if (!is_null($file)) {
-                return "<?php echo Laradown::loadStyle{$file}; ?>";
+            if (!empty($file)) {
+                return "<?php echo Markdown::loadStyle({$file}); ?>";
             }
 
-            return '<?php Markdown::loadStyle() ?>';
+            return '<?php Markdown::loadStyle(); ?>';
         });
 
         // Markdown Start Blade Directive
         Blade::directive('markdown', function ($markdown) {
-            if (!is_null($markdown)) {
-                return "<?php echo Laradown::convert{$markdown}; ?>";
+            if (!empty($markdown)) {
+                return "<?php echo Markdown::convert($markdown); ?>";
             }
 
-            return '<?php Markdown::collect() ?>';
+            return '<?php Markdown::collect(); ?>';
         });
 
         // Markdown End Blade Directive
         Blade::directive('endmarkdown', function () {
-            return '<?php echo Laradown::endCollect() ?>';
+            return '<?php echo Markdown::endCollect(); ?>';
         });
     }
 }


### PR DESCRIPTION
Hello,

I've been using Laradown for a bit now and was using the `Markdown::render()` call to output most of my content. I see the `markdown()` helper is working now, but I want to be able to leverage the blade directives. Here is my fix for them.

I didn't test the `@markdownstyle()` directive. I was primarily trying to get the `@markdown` and `@endmarkdown` directives working, but `@markdownstyle` should be working too.

It seems that null is never passed into the directive handlers, so the `!is_null()` check wasn't working. I've changed them to `!empty()` and they seem to be working now. 

I updated the facades to Markdown where they were set to Laradown and made sure the methods had parenthesis. I also added some additional semicolons for consistency.

Please let me know if you want anything revised.

Thanks!
Ned Fenstermacher